### PR TITLE
Added support for all IP allocation mode (DHCP, POOL or MANUAL)

### DIFF
--- a/modules/vcd_vapp_network.py
+++ b/modules/vcd_vapp_network.py
@@ -128,8 +128,8 @@ def vapp_network_argument_spec():
         fence_mode=dict(type='str', required=False, default=FenceMode.BRIDGED.value),
         parent_network=dict(type='str', required=False, default=None),
         ip_scope=dict(type='str', required=False, default=None),
-        dns1=dict(type='str', required=False, default=None),
-        dns2=dict(type='str', required=False, default=None),
+        dns1=dict(type='str', required=False, default=''),
+        dns2=dict(type='str', required=False, default=''),
         state=dict(choices=VAPP_NETWORK_STATES, required=True),
     )
 

--- a/modules/vcd_vapp_vm.py
+++ b/modules/vcd_vapp_vm.py
@@ -589,8 +589,17 @@ class VappVM(VcdAnsibleModule):
         vm = self.get_vm()
         nics = self.client.get_resource(vm.resource.get('href') + '/networkConnectionSection')
         for nic in nics.NetworkConnection:
+            if nic.IsConnected:
+                connected = "true"
+            else:
+                connected = "false"
             response['msg'].append({
                 'index': nic.NetworkConnectionIndex.text,
+                'connected': connected,
+                'allocation mode': nic.IpAddressAllocationMode.text,
+                'ip address': nic.IpAddress.text,
+                'mac address': nic.MACAddress.text,
+                'adapter': nic.NetworkAdapterType.text,
                 'network': nic.get('network')
             })
 

--- a/modules/vcd_vapp_vm.py
+++ b/modules/vcd_vapp_vm.py
@@ -331,6 +331,7 @@ class VappVM(VcdAnsibleModule):
         vmpassword_reset = params.get('vmpassword_reset')
         network = params.get('network')
         all_eulas_accepted = params.get('all_eulas_accepted')
+        deploy = params.get('deploy')
         power_on = params.get('power_on')
         ip_allocation_mode = params.get('ip_allocation_mode')
         cust_script = params.get('cust_script')
@@ -354,9 +355,9 @@ class VappVM(VcdAnsibleModule):
                 'network': network,
                 'cust_script': cust_script
             }
+            spec = {k: v for k, v in spec.items() if v}
             if storage_profile!='':
                 spec['storage_profile'] = self.get_storage_profile(storage_profile)
-            spec = {k: v for k, v in spec.items() if v}
             source_vm = self.vapp.to_sourced_item(spec)
 
             # Check the source vm if we need to inject OVF properties.
@@ -375,7 +376,7 @@ class VappVM(VcdAnsibleModule):
                 source_vm.InstantiationParams.append(productsection)
                 source_vm.VmGeneralParams.NeedsCustomization = E.NeedsCustomization('true')
 
-            params = E.RecomposeVAppParams(deploy='true', powerOn='true' if power_on else 'false')
+            params = E.RecomposeVAppParams(deploy='true' if deploy else 'false', powerOn='true' if power_on else 'false')
             params.append(source_vm)
             if all_eulas_accepted is not None:
                 params.append(E.AllEULAsAccepted(all_eulas_accepted))

--- a/modules/vcd_vapp_vm_nic.py
+++ b/modules/vcd_vapp_vm_nic.py
@@ -12,10 +12,10 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: vcd_vapp_vm_nic
-short_description: Ansible Module to manage (create/delete) NICs in vApp VMs in vCloud Director.
+short_description: Ansible Module to manage (add/delete/update) NICs in vApp VMs in vCloud Director.
 version_added: "2.4"
 description:
-    - "Ansible Module to manage (create/modify/delete) NICs in vApp VMs."
+    - "Ansible Module to manage (add/delete/update) NICs in vApp VMs."
 
 options:
     user:
@@ -44,19 +44,15 @@ options:
         required: false
     nic_id:
         description:
-            - NIC ID
+            - NIC ID (required for operation update, optional for state present)
+        required: false
+    nic_ids:
+        description:
+            - List of NIC IDs (required for state absent)
         required: false
     network:
         description:
-            - VApp network name
-        required: false
-    ip_allocation_mode:
-        description:
-            - IP allocation mode (DHCP, POOL or MANUAL)
-        required: false
-    ip_address:
-        description:
-            - NIC IP address (required for MANUAL IP allocation mode)
+            - vApp network name
         required: false
     vm_name:
         description:
@@ -70,6 +66,14 @@ options:
         description:
             - VDC name
         required: true
+    ip_allocation_mode:
+        description:
+            - IP allocation mode (DHCP, POOL or MANUAL)
+        required: false
+    ip_address:
+        description:
+            - NIC IP address (required for MANUAL IP allocation mode)
+        required: false
     state:
         description:
             - state of nic (present/absent).
@@ -77,7 +81,7 @@ options:
         required: true
     operation:
         description:
-            - operation on nic (update).
+            - operation on nic (update/read).
             - One from state or operation has to be provided.
         required: false
 author:
@@ -96,7 +100,7 @@ EXAMPLES = '''
     vm: "vm1"
     vapp = "vapp1"
     vdc = "vdc1"
-    nic_id = "2000"
+    nic_id = "2"
     ip_allocation_mode = "MANUAL"
     ip_address = "172.16.0.11"
     state = "present"
@@ -109,20 +113,21 @@ changed: true if resource has been changed else false
 
 from copy import deepcopy
 from lxml import etree
+from pyvcloud.vcd.vm import VM
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.vdc import VDC
-from pyvcloud.vcd.vapp import VApp
-from pyvcloud.vcd.vm import VM
 from pyvcloud.vcd.client import E
+from pyvcloud.vcd.vapp import VApp
+from collections import defaultdict
 from pyvcloud.vcd.client import E_RASD
-from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import NSMAP
+from pyvcloud.vcd.client import EntityType
 from ansible.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import EntityNotFoundException, OperationNotSupportedException
 
 
 VAPP_VM_NIC_STATES = ['present', 'absent']
-VAPP_VM_NIC_OPERATIONS = ['update']
+VAPP_VM_NIC_OPERATIONS = ['update', 'read']
 
 
 def vapp_vm_nic_argument_spec():
@@ -131,9 +136,10 @@ def vapp_vm_nic_argument_spec():
         vapp=dict(type='str', required=True),
         vdc=dict(type='str', required=True),
         nic_id=dict(type='int', required=False),
-        network=dict(type='str', required=False),
+        nic_ids=dict(type='list', required=False),
         ip_allocation_mode=dict(type='str', required=False, default='DHCP'),
         ip_address=dict(type='str', required=False, default=''),
+        network=dict(type='str', required=False),
         state=dict(choices=VAPP_VM_NIC_STATES, required=False),
         operation=dict(choices=VAPP_VM_NIC_OPERATIONS, required=False),
     )
@@ -148,7 +154,8 @@ class VappVMNIC(VcdAnsibleModule):
     def manage_states(self):
         state = self.params.get('state')
         if state == "present":
-            return self.add_nic()
+            #return self.add_nic()
+            return self.add_update_nic()
 
         if state == "absent":
             return self.delete_nic()
@@ -156,8 +163,14 @@ class VappVMNIC(VcdAnsibleModule):
     def manage_operations(self):
         operation = self.params.get('operation')
         if operation == "update":
-            #return self.update_nic()
-            return self.add_nic("update")
+            network = self.params.get('network')
+            if network:
+                return self.add_update_nic("update")
+            else:
+                return self.update_nic()
+
+        if operation == "read":
+            return self.read_nics()
 
     def get_resource(self):
         vapp = self.params.get('vapp')
@@ -174,104 +187,230 @@ class VappVMNIC(VcdAnsibleModule):
 
         return VM(self.client, resource=vapp_vm_resource)
 
-    # add_nic used to create a nic (default) or to modify an existing one (op = "update")
-    def add_nic(self, op = "create"):
+    def get_vm_nics(self):
         vm = self.get_vm()
+        return self.client.get_resource(vm.resource.get('href') + '/networkConnectionSection')
+
+    def add_update_nic(self, op = "add"):
+        '''
+            Used to add a nic (default)
+            or to modify an existing one (op = "update") if network change is needed
+            
+            Error - More than 10 Nics are not permissible in vCD
+        '''
+        vm = self.get_vm()
+        vm_name = self.params.get('vm_name')
         nic_id = self.params.get('nic_id')
         network = self.params.get('network')
-        ip_allocation_mode = self.params.get('ip_allocation_mode')
         ip_address = self.params.get('ip_address')
-        response = dict()
+        ip_allocation_mode = self.params.get('ip_allocation_mode')
+        uri = vm.resource.get('href') + '/networkConnectionSection'
+        response = defaultdict(dict)
         response['changed'] = False
+        new_nic_id = None
         note = 'added'
-        max_id = -1;
-        index = -1
+        nic_found = False
 
-        nics = self.client.get_resource(vm.resource.get('href') + '/networkConnectionSection')
+        nics = self.get_vm_nics()
+        nics_indexes = [int(nic.NetworkConnectionIndex) for nic in nics.NetworkConnection]
+        nics_indexes.sort()
+
         for nic in nics.NetworkConnection:
             if nic.NetworkConnectionIndex == nic_id:
-                index = nic_id
-                if op == "create":
+                nic_found = True
+                if op == "add":
                     response['warnings'] = 'NIC is already present.'
                     return response
                 else:
                     note = 'updated'
-            if nic.NetworkConnectionIndex > max_id:
-                max_id = int(nic.NetworkConnectionIndex.text)
 
-        if index < 0 and op == "update":
+        if not nic_found and op == "update":
             response['warnings'] = 'NIC not found.'
             return response
 
-        nic = E.NetworkConnection(
-            E.NetworkConnectionIndex(max_id+1 if nic_id is None else nic_id),
-            E.IpAddress(ip_address),
-            E.IsConnected(True),
-            E.IpAddressAllocationMode(ip_allocation_mode),
-            network=network)
+        if nic_id is None:
+            for index, nic_index in enumerate(nics_indexes):
+                new_nic_id = nic_index + 1
+                if index != nic_index:
+                    new_nic_id = index
+                    break
+            nic_id = new_nic_id
+
+        if ip_allocation_mode in ('DHCP', 'POOL'):
+            nic = E.NetworkConnection(
+                E.NetworkConnectionIndex(nic_id),
+                E.IsConnected(True),
+                E.IpAddressAllocationMode(ip_allocation_mode),
+                network=network)
+        else:
+            if not ip_address:
+                raise Exception('IpAddress is missing.')
+            nic = E.NetworkConnection(
+                E.NetworkConnectionIndex(nic_id),
+                E.IpAddress(ip_address),
+                E.IsConnected(True),
+                E.IpAddressAllocationMode(ip_allocation_mode),
+                network=network)
+
         nics.NetworkConnection.addnext(nic)
-
-        add_nic_task = self.client.put_resource(
-            vm.resource.get('href') + '/networkConnectionSection', nics,
-            EntityType.NETWORK_CONNECTION_SECTION.value)
+        add_nic_task = self.client.put_resource(uri, nics, EntityType.NETWORK_CONNECTION_SECTION.value)
         self.execute_task(add_nic_task)
-
-        response['msg'] = 'Vapp VM NIC has been ' + note + '.'
+        response['msg'] = {
+            'vApp VM NIC:': note,
+            'nic_id': nic_id,
+            'ip_allocation_mode': ip_allocation_mode,
+            'ip_address': ip_address,
+            'network': network
+        }
         response['changed'] = True
+
+        return response
+
+    def add_nic(self):
+        '''
+            Error - More than 10 Nics are not permissible in vCD
+        '''
+        vm = self.get_vm()
+        vm_name = self.params.get('vm_name')
+        network = self.params.get('network')
+        ip_address = self.params.get('ip_address')
+        ip_allocation_mode = self.params.get('ip_allocation_mode')
+        uri = vm.resource.get('href') + '/networkConnectionSection'
+        response = defaultdict(dict)
+        response['changed'] = False
+        new_nic_id = None
+
+        nics = self.get_vm_nics()
+        nics_indexes = [int(nic.NetworkConnectionIndex) for nic in nics.NetworkConnection]
+        nics_indexes.sort()
+        for index, nic_index in enumerate(nics_indexes):
+            new_nic_id = nic_index + 1
+            if index != nic_index:
+                new_nic_id = index
+                break
+
+        if ip_allocation_mode not in ('DHCP', 'POOL', 'MANUAL'):
+            raise Exception('IpAllocationMode should be one of DHCP/POOL/MANUAL')
+
+        if ip_allocation_mode in ('DHCP', 'POOL'):
+            nic = E.NetworkConnection(
+                E.NetworkConnectionIndex(new_nic_id),
+                E.IsConnected(True),
+                E.IpAddressAllocationMode(ip_allocation_mode),
+                network=network)
+        else:
+            if not ip_address:
+                raise Exception('IpAddress is missing.')
+            nic = E.NetworkConnection(
+                E.NetworkConnectionIndex(new_nic_id),
+                E.IpAddress(ip_address),
+                E.IsConnected(True),
+                E.IpAddressAllocationMode(ip_allocation_mode),
+                network=network)
+
+        nics.NetworkConnection.addnext(nic)
+        add_nic_task = self.client.put_resource(uri, nics, EntityType.NETWORK_CONNECTION_SECTION.value)
+        self.execute_task(add_nic_task)
+        response['msg'] = {
+            'nic_id': new_nic_id, 
+            'ip_allocation_mode': ip_allocation_mode,
+            'ip_address': ip_address
+        }
+        response['changed'] = True
+
+        return response
+
+    def update_nic(self):
+        '''
+            Following update scenarios are covered
+            1. IP allocation mode change: DHCP, POOL, MANUAL
+            2. Update IP address in MANUAL mode
+            
+            If network change is needed, add_update_nic is used
+        '''
+        vm = self.get_vm()
+        nic_id = self.params.get('nic_id')
+        network = self.params.get('network')
+        ip_address = self.params.get('ip_address')
+        ip_allocation_mode = self.params.get('ip_allocation_mode')
+        uri = vm.resource.get('href') + '/networkConnectionSection'
+        response = defaultdict(dict)
+        response['changed'] = False
+
+        nics = self.get_vm_nics()
+        nic_indexs = [nic.NetworkConnectionIndex for nic in nics.NetworkConnection]
+        if nic_id not in nic_indexs:
+            response['warnings'] = 'NIC not found.'
+            return response
+        nic_to_update = nic_indexs.index(nic_id)
+
+        if network:
+            nics.NetworkConnection[nic_to_update].network = network
+            response['changed'] = True
+
+        if ip_allocation_mode:
+            allocation_mode_element = E.IpAddressAllocationMode(ip_allocation_mode)
+            nics.NetworkConnection[nic_to_update].IpAddressAllocationMode = allocation_mode_element
+            response['changed'] = True
+
+        if ip_address:
+            nics.NetworkConnection[nic_to_update].IpAddress = E.IpAddress(ip_address)
+            response['changed'] = True
+
+        if response['changed']:
+            update_nic_task = self.client.put_resource(uri, nics, EntityType.NETWORK_CONNECTION_SECTION.value)
+            self.execute_task(update_nic_task)
+            response['msg'] = 'vApp VM nic has been updated.'
+
+        return response
+
+    def read_nics(self):
+        vm = self.get_vm()
+        response = defaultdict(dict)
+        response['changed'] = False
+
+        nics = self.get_vm_nics()
+        for nic in nics.NetworkConnection:
+            meta = defaultdict(dict)
+            nic_id = str(nic.NetworkConnectionIndex)
+            meta['MACAddress'] = str(nic.MACAddress)
+            meta['IsConnected'] = str(nic.IsConnected)
+            meta['NetworkAdapterType'] = str(nic.NetworkAdapterType)
+            meta['NetworkConnectionIndex'] = str(nic.NetworkConnectionIndex)
+            meta['IpAddressAllocationMode'] = str(nic.IpAddressAllocationMode)
+
+            if hasattr(nic, 'IpAddress'):
+                meta['IpAddress'] = str(nic.IpAddress)
+
+            response['msg'][nic_id] = meta
 
         return response
 
     def delete_nic(self):
         vm = self.get_vm()
-        nic_id = self.params.get('nic_id')
-        response = dict()
+        nic_ids = self.params.get('nic_ids')
+        response = defaultdict(dict)
         response['changed'] = False
+        uri = vm.resource.get('href') + '/networkConnectionSection'
 
-        nics = self.client.get_resource(vm.resource.get('href') + '/networkConnectionSection')
+        nics = self.get_vm_nics()
         for nic in nics.NetworkConnection:
-            if nic.NetworkConnectionIndex == nic_id:
+            if nic.NetworkConnectionIndex in nic_ids:
                 nics.remove(nic)
-                remove_nic_task = self.client.put_resource(
-                    vm.resource.get('href') + '/networkConnectionSection', nics,
-                    EntityType.NETWORK_CONNECTION_SECTION.value)
-                self.execute_task(remove_nic_task)
-                response['msg'] = 'VM nic has been deleted.'
-                response['changed'] = True
-                return response
+                nic_ids.remove(nic.NetworkConnectionIndex)
 
-        response['warnings'] = 'VM nic was not found'
-        return response
+        if len(nic_ids) > 0:
+            nic_ids = [str(nic_id) for nic_id in nic_ids]
+            err_msg = 'Can\'t find the specified VM nic(s) {0}'.format(','.join(nic_ids))
+            raise EntityNotFoundException(err_msg)
 
-    # update_nic no more used -> replaced by add_nic("update")
-    def update_nic(self):
-        vm = self.get_vm()
-        nic_id = self.params.get('nic_id')
-        network = self.params.get('network')
-        response = dict()
-        response['changed'] = False
-
-        nics = self.client.get_resource(vm.resource.get('href') + '/networkConnectionSection')
-        index = -1
-
-        for i, nic in enumerate(nics.NetworkConnection):
-            if nic.NetworkConnectionIndex == nic_id:
-                index = i
-
-        if index < 0:
-            EntityNotFoundException('Can\'t find the specified VM nic')
-
-        if network:
-            nics.NetworkConnection[index].set('network', network)
-            response['changed'] = True
-
-        if response['changed']:
-            update_nic_task = self.client.put_resource(
-                vm.resource.get('href') + '/networkConnectionSection', nics,
-                EntityType.NETWORK_CONNECTION_SECTION.value)
-            self.execute_task(update_nic_task)
-            response['msg'] = 'Vapp VM nic has been updated.'
+        remove_nic_task = self.client.put_resource(uri, nics, EntityType.NETWORK_CONNECTION_SECTION.value)
+        self.execute_task(remove_nic_task)
+        response['msg'] = 'VM nic(s) has been deleted.'
+        response['changed'] = True
 
         return response
+
 
 def main():
     argument_spec = vapp_vm_nic_argument_spec()


### PR DESCRIPTION
I wasn't able to create a VM with manual ip address (see issue #15) so I worked on `vcd_vapp_vm_nic.py` focused on nics (see  #20).
Finally I was able to add new nic with all allocation mode, I've added a small change to modify also an existing nic.
I see there's a function called `update_nic` but it seems to me is useful just to change network, not allocation mode.
