### PR TITLE
Updated README with python version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ansible-module-vcloud-director is a set of ansible modules that manage a VMware 
 ### Prerequisites
 
 * The [pyvcloud](https://github.com/vmware/pyvcloud) module is required. 
-* vCD Ansible modules require Python 3.
+* vCD Ansible modules require Python 3.6 or above.
 
 ### Build & Run
 


### PR DESCRIPTION
Python version 3.6 or above required for pyvcloud SDK hence the ansible module.
Fixes #44

Signed-off-by: Chaminda Divitotawela <cdivitotawela@gmail.com>