### PR TITLE
Updated the org task main file to work dynamically

### DIFF
--- a/roles/org/tasks/main.yml
+++ b/roles/org/tasks/main.yml
@@ -4,7 +4,12 @@
 # ---
 # tasks file for roles/org
 
-# # ############################################ Create Org ##############################################################
+# # ########################################### Get the Organization Status #############################################
+- name: Get Organisation State
+  set_fact:
+    org_state: "{{ state }}"
+
+# # ############################################ Create/Update Org ##############################################################
 - name: create org
   vcd_org:
     user: XXXXXXXXXX
@@ -14,57 +19,11 @@
     org_name: "{{ org_name }}"
     full_name: "{{ org_full_name }}"
     is_enabled : "{{ is_enabled }}"
-    state: "present"
+    state: {{ org_state }}
   register: output
+  when: state == "present" or state == "update"
 
-- name: create org output
-  debug:
-    msg: '{{ output }}'
-
-# # ############################################ Read Org ##############################################################
-- name: read org
-  vcd_org:
-    user: XXXXXXXXXX
-    password: XXXXXXXXXX
-    host: XXXXXXXXXX
-    org: XXXXXXXXXX
-    org_name: "{{ org_name }}"
-    operation: "read"
-  register: output
-
-- name: read org output
-  debug:
-    msg: '{{ output }}'
-
-# # ############################################ Disable Org ##############################################################
-- name: disable org
-  vcd_org:
-    user: XXXXXXXXXX
-    password: XXXXXXXXXX
-    host: XXXXXXXXXX
-    org: XXXXXXXXXX
-    org_name: "{{ org_name }}"
-    is_enabled: "false"
-    state: "update"
-  register: output
-
-- name: disable org output
-  debug:
-    msg: '{{ output }}'
-
-# # # ############################################ Enable Org ##############################################################
-- name: enable org
-  vcd_org:
-    user: XXXXXXXXXX
-    password: XXXXXXXXXX
-    host: XXXXXXXXXX
-    org: XXXXXXXXXX
-    org_name: "{{ org_name }}"
-    is_enabled: "true"
-    state: "update"
-  register: output
-
-- name: enable org output
+- name: delete org output
   debug:
     msg: '{{ output }}'
 
@@ -78,9 +37,11 @@
     org_name: "{{ org_name }}"
     force: "{{ force }}"
     recursive: "{{ recursive }}"
-    state: "absent"
+    state: {{ org_state }}
   register: output
+  when: state == "absent"
 
 - name: delete org output
   debug:
     msg: '{{ output }}'
+

--- a/roles/org/vars/main.yml
+++ b/roles/org/vars/main.yml
@@ -6,7 +6,10 @@
 org_name: "test_org_100"
 org_full_name: "test_org_full_name_100"
 
-#org enabled
+#Org State: present, update or absent
+state: present 
+
+#org enabled: true or false
 is_enabled: True
 
 #Force delete org


### PR DESCRIPTION
The Current Playbook has provided examples to create, update, read and delete the organization.
I have modified the playbook to have all the operations and work according to the input variables.

Playbook will get the organization status using set_fact. with the when condition respective task will run. Be it create/Update or Delete.

user wouldn't have to worry about changing/clearing the unnecessary tasks.