### PR TITLE
Add operations list_users, list_vdcs, set_metadata

### DIFF
--- a/modules/vcd_org.py
+++ b/modules/vcd_org.py
@@ -62,6 +62,17 @@ options:
         description:
             - recursive delete org
         required: false
+    metadata:
+        description:
+            - dict to set, delete or update metadata
+            - Example:
+              metadata:
+                - state: 'present'                                             # optional, present (will also update value), absent, default: present
+                  name: 'keyX'                                                 # mandatory, unique name of metadata-entry
+                  value: 'valueY'                                              # mandatory, if state present, else optional as it will be ignored
+                  type: 'STRING'                                               # optional, STRING, NUMBER, BOOLEAN, DATA_TIME, default: STRING
+                  visibility: 'READONLY'                                       # optional, PRIVATE, READONLY, READ_WRITE, default: READONLY
+        required: false
     state:
         description:
             - state of org
@@ -104,11 +115,13 @@ changed: true if resource has been changed else false
 from lxml import etree
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.system import System
+from pyvcloud.vcd.client import E, EntityType, RelationType, ResourceType, MetadataDomain, MetadataVisibility, MetadataValueType
+from pyvcloud.vcd.utils import to_dict
 from ansible.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import EntityNotFoundException, BadRequestException
 
 VCD_ORG_STATES = ['present', 'absent', 'update']
-VCD_ORG_OPERATIONS = ['read']
+VCD_ORG_OPERATIONS = ['read','list_users','list_vdcs','set_metadata']
 
 
 def org_argument_spec():
@@ -118,6 +131,7 @@ def org_argument_spec():
         is_enabled=dict(type='bool', required=False, default=False),
         force=dict(type='bool', required=False, default=None),
         recursive=dict(type='bool', required=False, default=None),
+        metadata=dict(type='list', required=False, default='[]'),
         state=dict(choices=VCD_ORG_STATES, required=False),
         operation=dict(choices=VCD_ORG_OPERATIONS, required=False),
     )
@@ -144,11 +158,18 @@ class VCDOrg(VcdAnsibleModule):
         operation = self.params.get('operation')
         if operation == "read":
             return self.read()
+        if operation == "list_users":
+            return self.list_users()
+        if operation == "list_vdcs":
+            return self.list_vdcs()
+        if operation == "set_metadata":
+            return self.set_metadata()
 
     def create(self):
         org_name = self.params.get('org_name')
         full_name = self.params.get('full_name')
         is_enabled = self.params.get('is_enabled')
+        metadata = self.params.get('metadata')
         response = dict()
         response['changed'] = False
 
@@ -208,6 +229,80 @@ class VCDOrg(VcdAnsibleModule):
 
         return response
 
+    def list_users(self):
+        org_name = self.params.get('org_name')
+        response = dict()
+        org_details = dict()
+        response['users'] = list()
+        response['changed'] = False
+
+        resource = self.client.get_org_by_name(org_name)
+        org = Org(self.client, resource=resource)
+        org_user_list = org.list_users()
+        resource_type = ResourceType.USER.value
+        if self.client.is_sysadmin():
+            resource_type = ResourceType.ADMIN_USER.value
+        for org_user in org_user_list:
+            response['users'].append(
+                to_dict(org_user, resource_type=resource_type, exclude=[]))
+
+        return response
+    
+    def list_vdcs(self):
+        org_name = self.params.get('org_name')
+        response = dict()
+        org_details = dict()
+        response['vdcs'] = list()
+        response['changed'] = False
+
+        resource = self.client.get_org_by_name(org_name)
+        org = Org(self.client, resource=resource)
+        response['vdcs'] = org.list_vdcs()
+
+        return response
+    
+    def set_metadata(self):
+        '''
+        Expects metadata as following:
+        metadata:
+          - state: 'present'                                             # optional, present (will also update value), absent, default: present
+            name: 'keyX'                                                 # mandatory, unique name of metadata-entry
+            value: 'valueY'                                              # mandatory, if state present, else optional as it will be ignored
+            type: 'STRING'                                               # optional, STRING, NUMBER, BOOLEAN, DATA_TIME, default: STRING
+            visibility: 'READONLY'                                       # optional, PRIVATE, READONLY, READ_WRITE, default: READONLY
+        '''
+        org_name = self.params.get('org_name')
+        metadata = self.params.get('metadata')
+        response = dict()
+        response['msg'] = ''
+        
+        if len(metadata) != 0:
+            # workaround to set metadata for org as it is as of now not implemented in pyvcloud for org, vdc, e.g. - we will open a pull request to fix this in the future
+            resource = self.client.get_linked_resource(self.client.get_org_by_name(org_name), RelationType.DOWN, EntityType.METADATA.value)
+            self.metadata = Metadata(self.client, resource=resource)
+            for md in metadata:
+                domain = MetadataDomain.SYSTEM
+                visibility = MetadataVisibility.READONLY
+                if type(md) is dict and md.get('state', 'present') == 'absent':
+                    if md.get('visibility', 'READONLY').upper() == 'READWRITE':
+                        domain = MetadataDomain.GENERAL
+                    self.metadata.remove_metadata()
+                else:
+                    if md.get('visibility', 'READONLY').upper() == 'PRIVATE':
+                        visibility = MetadataVisibility.PRIVATE
+                    elif md.get('visibility', 'READONLY').upper() == 'READWRITE':
+                        domain = MetadataDomain.GENERAL
+                        visibility = MetadataVisibility.READWRITE
+                    value_type = MetadataValueType.STRING
+                    if md.get('type', 'STRING').upper() == 'NUMBER':
+                        value_type = MetadataValueType.NUMBER
+                    elif md.get('type', 'STRING').upper() == 'BOOLEAN':
+                        value_type = MetadataValueType.BOOLEAN
+                    elif md.get('type', 'STRING').upper() == 'DATA_TIME':
+                        value_type = MetadataValueType.DATA_TIME
+                    self.metadata.set_metadata(md['name'], md['value'], domain, visibility, value_type, True)
+        
+        return response
 
 def main():
     argument_spec = org_argument_spec()


### PR DESCRIPTION
Hello altogether,

first pull request, so please be patient with me.

In my company PlusServer we use several vCD in different regions, so I took the time and made some changes (I hope improvements) all over the board for these modules.

I will contribute them bit by bit, starting with something small here: `vcd_org.py`

Here we needed just some additional operations to get info on orgs.

# list_users
returns key `users` with dicts of users as per pyvclouds [org.list_users()](https://github.com/vmware/pyvcloud/blob/master/pyvcloud/vcd/org.py#L1024) and [utils.to_dict()](https://github.com/vmware/pyvcloud/blob/master/pyvcloud/vcd/utils.py#L680)

# list_vdcs
returns key `vdcs` with dicts of vdcs as per pyvclouds [org.list_vdcs()](https://github.com/vmware/pyvcloud/blob/master/pyvcloud/vcd/org.py#L1611)

# set_metadata
expects key `metadata` and sets metadata on org via pyvclouds [metadata.set_metadata()](https://github.com/vmware/pyvcloud/blob/master/pyvcloud/vcd/metadata.py#L90)
<br>Input-Data:
```
metadata:
  - state: 'present'                                             # optional, present (will also update value), absent, default: present
    name: 'keyX'                                                 # mandatory, unique name of metadata-entry
    value: 'valueY'                                              # mandatory, if state present, else optional as it will be ignored
    type: 'STRING'                                               # optional, STRING, NUMBER, BOOLEAN, DATA_TIME, default: STRING
    visibility: 'READONLY'                                       # optional, PRIVATE, READONLY, READ_WRITE, default: READONLY
```



Following are some of the bigger changes that I can provide in following PRs.
# Possible future PRs
## all modules
- added handling for newer pyvcloud-versions (raises no EntityNotFoundException anymore)
- added parameter org_name to all modules to be usable to define a different target Organization from what the user is logged in to
## vcd_org_vdc
- added metadata creation on states "present" and "update" as well as deletion on state "update"
- added operation to set metadata on storage_profiles / storage policies
- added operation to list all vApps of a vdc
- added operation to list all networks of a vdc
- removed any defaults as this is not good practice and can not be combined for update-tasks where you want the user to define what to update
- added proper update-state, as previously nothing but "IsEnabled" of a vdc could be updated (and was not supported anymore "OperationNotSupportedException")
## vcd_vapp
- changed network to be optional for cloning from Template/vApp-VM
- added operation shutdown
- added metadata creation on states "present" and "update" as well as deletion on state "update"
## vcd_catalog
- added operation to share catalogs with specific Organizations
## vcd_vdc_network
- added possibility to delete networks without specifiying network type to vcd_vdc_network
## vcd_vapp_vm
- added parameter force_guest_customizations and power_on handling for operation "deploy"
- added operation "upgrade_virtual_hardware"
- added metadata creation on states "present" and "update" as well as deletion on state "update"
## vcd_vapp_vm_nic
- fixed NIC handling to NOT update nics, if no changes are necessary
- added primary, connected and adapter-type handling
## vcd_vdc_gateway
- changed input vars and creation handling of edge gateways
- added firewall-rule-handling and implemented it besides pyvcloud, as pyvclouds solution does not work with gateways in formfactor compact
- added NAT-rule-handling (leads to new python requirement: netaddr)
- updating of edge gateways in vcd_vdc_gateway.py
  - add, remove (and split) suballocated ip-ranges
  - editing rate-limits
  - add/remove subnets
  - add/remove external networks
## new module: vcd_platform
- following operations are included:
  - list all provider vdcs of a vCloud Director
  - list all network pools of a vCloud Director
  - get vcenter of a pvdc
  - get the least used provider vdc of a vCloud Director
  - get the provider vdc of a vdc
  - get the network pool of a provider vdc
  - get all storage profiles of a provider vdc
## new module: vcd_external_network
- can as of now only: add, remove vCD external networks