### PR TITLE
allow 0 for resource_guaranteed

### DIFF
--- a/modules/vcd_org_vdc.py
+++ b/modules/vcd_org_vdc.py
@@ -278,8 +278,8 @@ def org_vdc_argument_spec():
         network_quota=dict(type='int', required=False),
         vm_quota=dict(type='int', required=False),
         storage_profiles=dict(type='list', required=False, default=[]),
-        resource_guaranteed_memory=dict(type='float', required=False),
-        resource_guaranteed_cpu=dict(type='float', required=False),
+        resource_guaranteed_memory=dict(type='float', required=False, default=1.0),
+        resource_guaranteed_cpu=dict(type='float', required=False, default=1.0),
         vcpu_in_mhz=dict(type='int', required=False),
         is_thin_provision=dict(type='bool', required=False),
         network_pool_name=dict(type='str', required=False),
@@ -355,8 +355,8 @@ class Vdc(VcdAnsibleModule):
         nic_quota = self.params['nic_quota'] or 0
         network_quota = self.params['network_quota'] or 0
         vm_quota = self.params['vm_quota'] or 0
-        resource_guaranteed_memory = self.params['resource_guaranteed_memory'] or 1.0
-        resource_guaranteed_cpu = self.params['resource_guaranteed_cpu'] or 1.0
+        resource_guaranteed_memory = self.params['resource_guaranteed_memory']
+        resource_guaranteed_cpu = self.params['resource_guaranteed_cpu']
         vcpu_in_mhz = self.params['vcpu_in_mhz']
         is_thin_provision = self.params['is_thin_provision']
         network_pool_name = self.params['network_pool_name']


### PR DESCRIPTION
Fixes issue [#189](https://github.com/vmware/ansible-module-vcloud-director/issues/189) preventing 0 resource reservation.

Signed-off-by: Hunter Christain <47791064+exp-hc@users.noreply.github.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/ansible-module-vcloud-director/191)
<!-- Reviewable:end -->
