### PR TITLE
Fixing module_utils import for collections

### DIFF
--- a/plugins/modules/vcd_catalog.py
+++ b/plugins/modules/vcd_catalog.py
@@ -90,7 +90,7 @@ changed: true if resource has been changed else false
 
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.client import NSMAP
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 
 

--- a/plugins/modules/vcd_catalog_item.py
+++ b/plugins/modules/vcd_catalog_item.py
@@ -111,7 +111,7 @@ from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.vapp import VApp
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.client import QueryResultFormat
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 
 VCD_CATALOG_ITEM_STATES = ["present", "absent"]

--- a/plugins/modules/vcd_disk.py
+++ b/plugins/modules/vcd_disk.py
@@ -124,7 +124,7 @@ changed: true if resource has been changed else false
 
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.vdc import VDC
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 
 

--- a/plugins/modules/vcd_external_network.py
+++ b/plugins/modules/vcd_external_network.py
@@ -136,7 +136,7 @@ changed: true if resource has been changed else false
 
 
 from pyvcloud.vcd.platform import Platform
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.external_network import ExternalNetwork
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 

--- a/plugins/modules/vcd_gateway_services.py
+++ b/plugins/modules/vcd_gateway_services.py
@@ -114,12 +114,12 @@ changed: true if resource has been changed else false
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.vdc import VDC
 from pyvcloud.vcd.gateway import Gateway
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import EntityNotFoundException
-from ansible.module_utils.gateway_static_route import StaticRoutes
-from ansible.module_utils.gateway_nat_rule_service import NatRuleService
-from ansible.module_utils.gateway_firewall_service import FirewallService
-from ansible.module_utils.gateway_ssl_certificates import SSLCertificates
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.gateway_static_route import StaticRoutes
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.gateway_nat_rule_service import NatRuleService
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.gateway_firewall_service import FirewallService
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.gateway_ssl_certificates import SSLCertificates
 
 
 EDGE_SERVICES = ["firewall", "nat_rule", "static_route", "ssl_certificates"]

--- a/plugins/modules/vcd_org.py
+++ b/plugins/modules/vcd_org.py
@@ -93,7 +93,7 @@ changed: true if resource has been changed else false
 from lxml import etree
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.system import System
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import EntityNotFoundException, BadRequestException
 
 

--- a/plugins/modules/vcd_org_vdc.py
+++ b/plugins/modules/vcd_org_vdc.py
@@ -239,7 +239,7 @@ changed: true if resource has been changed else false
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.vdc import VDC
 from pyvcloud.vcd.system import System
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
 

--- a/plugins/modules/vcd_resources.py
+++ b/plugins/modules/vcd_resources.py
@@ -71,7 +71,7 @@ changed: true if resource has been changed
 """
 
 
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.nsxt_extension import NsxtExtension
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 

--- a/plugins/modules/vcd_roles.py
+++ b/plugins/modules/vcd_roles.py
@@ -98,7 +98,7 @@ from pyvcloud.vcd.client import E
 from pyvcloud.vcd.system import System
 from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import RelationType
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 
 

--- a/plugins/modules/vcd_user.py
+++ b/plugins/modules/vcd_user.py
@@ -155,7 +155,7 @@ changed: true if resource has been changed else false
 
 
 from pyvcloud.vcd.org import Org
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 
 

--- a/plugins/modules/vcd_vapp.py
+++ b/plugins/modules/vcd_vapp.py
@@ -182,7 +182,7 @@ from pyvcloud.vcd.client import FenceMode
 from pyvcloud.vcd.client import MetadataDomain
 from pyvcloud.vcd.client import MetadataValueType
 from pyvcloud.vcd.client import MetadataVisibility
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import EntityNotFoundException, OperationNotSupportedException, InvalidStateException
 
 

--- a/plugins/modules/vcd_vapp_network.py
+++ b/plugins/modules/vcd_vapp_network.py
@@ -133,7 +133,7 @@ from pyvcloud.vcd.vapp import VApp
 from collections import defaultdict
 from pyvcloud.vcd.client import NSMAP
 from pyvcloud.vcd.client import EntityType
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
 

--- a/plugins/modules/vcd_vapp_vm.py
+++ b/plugins/modules/vcd_vapp_vm.py
@@ -202,7 +202,7 @@ from pyvcloud.vcd.client import RelationType
 from pyvcloud.vcd.client import MetadataDomain
 from pyvcloud.vcd.client import MetadataValueType
 from pyvcloud.vcd.client import MetadataVisibility
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import EntityNotFoundException, OperationNotSupportedException
 
 

--- a/plugins/modules/vcd_vapp_vm_disk.py
+++ b/plugins/modules/vcd_vapp_vm_disk.py
@@ -104,7 +104,7 @@ from pyvcloud.vcd.vdc import VDC
 from pyvcloud.vcd.vapp import VApp
 from pyvcloud.vcd.client import NSMAP
 from pyvcloud.vcd.client import EntityType
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 
 

--- a/plugins/modules/vcd_vapp_vm_nic.py
+++ b/plugins/modules/vcd_vapp_vm_nic.py
@@ -120,7 +120,7 @@ from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.vdc import VDC
 from pyvcloud.vcd.vapp import VApp
 from pyvcloud.vcd.client import EntityType
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
 from pyvcloud.vcd.exceptions import EntityNotFoundException, InvalidParameterException
 

--- a/plugins/modules/vcd_vapp_vm_snapshot.py
+++ b/plugins/modules/vcd_vapp_vm_snapshot.py
@@ -83,7 +83,7 @@ from pyvcloud.vcd.vm import VM
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.vdc import VDC
 from pyvcloud.vcd.vapp import VApp
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
 
 

--- a/plugins/modules/vcd_vdc_gateway.py
+++ b/plugins/modules/vcd_vdc_gateway.py
@@ -221,7 +221,7 @@ changed: true if resource has been changed else false
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.vdc import VDC
 from pyvcloud.vcd.gateway import Gateway
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import BadRequestException, EntityNotFoundException
 
 

--- a/plugins/modules/vcd_vdc_network.py
+++ b/plugins/modules/vcd_vdc_network.py
@@ -169,7 +169,7 @@ changed: true if resource has been changed else false
 
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.vdc import VDC
-from ansible.module_utils.vcd import VcdAnsibleModule
+from ansible_collections.vmware.vcloud_director.plugins.module_utils.vcd import VcdAnsibleModule
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 
 


### PR DESCRIPTION
Now the following error:

`fatal: [localhost]: FAILED! => {"msg": "Could not find imported module support code for ansible_collections.vmware.vcloud_director.plugins.modules.vcd_vapp.  Looked for (['ansible.module_utils.vcd.VcdAnsibleModule', 'ansible.module_utils.vcd'])"}`

Problem:

_When coding with module_utils in a collection, the Python import statement needs to take into account the FQCN along with the ansible_collections convention. The resulting Python import will look like from ansible_collections.{namespace}.{collection}.plugins.module_utils.{util} import {something}_


[link to documentation](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_structure.html#module-utils)