### PR TITLE
Move logic out of except block

### DIFF
--- a/modules/vcd_vapp.py
+++ b/modules/vcd_vapp.py
@@ -327,8 +327,11 @@ class Vapp(VcdAnsibleModule):
         response['changed'] = False
 
         try:
-            self.vdc.get_vapp(vapp_name)
+            found = self.vdc.get_vapp(vapp_name)
         except EntityNotFoundException:
+            found = None
+
+        if not found:
             create_vapp_task = self.vdc.instantiate_vapp(
                 name=vapp_name,
                 catalog=catalog_name,
@@ -377,8 +380,11 @@ class Vapp(VcdAnsibleModule):
         response['changed'] = False
 
         try:
-            self.vdc.get_vapp(vapp_name)
+            found = self.vdc.get_vapp(vapp_name)
         except EntityNotFoundException:
+            found = None
+
+        if not found:
             create_vapp_task = self.vdc.create_vapp(
                 name=vapp_name,
                 description=description,
@@ -402,8 +408,11 @@ class Vapp(VcdAnsibleModule):
         response['changed'] = False
 
         try:
-            self.vdc.get_vapp(vapp_name)
+            found = self.vdc.get_vapp(vapp_name)
         except EntityNotFoundException:
+            found = None
+
+        if not found:
             response['warnings'] = "Vapp {} is not present.".format(vapp_name)
         else:
             delete_vapp_task = self.vdc.delete_vapp(

--- a/modules/vcd_vapp_vm.py
+++ b/modules/vcd_vapp_vm.py
@@ -384,8 +384,11 @@ class VappVM(VcdAnsibleModule):
         response['changed'] = False
 
         try:
-            self.get_vm()
+            found = self.get_vm()
         except EntityNotFoundException:
+            found = None
+
+        if not found:
             spec = {
                 'source_vm_name': source_vm_name,
                 'vapp': source_vapp_resource,


### PR DESCRIPTION
Add extra if-else statement, so that code for typical scenarios is not executed within except-else block. This will simplify error printouts, avoiding some `During handling of the above exception, another exception occurred: ...`