### PR TITLE
Add authentication via API token

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,9 @@ The end user can set login variables for specific module(s) as local variables. 
 <p>
 By default, the priority will be given to <b>Local Variables</b> than <b>Environment Variables.</b>
 </p>
+<p>
+If "API_TOKEN" is passed in the <code>user</code> variable the <code>password</code> variable will be interpreted as <a href=https://docs.vmware.com/en/VMware-Cloud-Director/10.4/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-A1B3B2FA-7B2C-4EE1-9D1B-188BE703EEDE.html>API Access Token</a> and OAuth 2.0 based authentication is used instead of user credentials. This is useful if an <a href=https://docs.vmware.com/en/VMware-Cloud-Director/10.4/VMware-Cloud-Director-Service-Provider-Admin-Portal-Guide/GUID-3326986B-931C-4FDE-AF47-D5A863191072.html>external identity provider</a> is configured for the authentication with vCloud Director.
+</p>
 <li>
 <h3>Response</h3>
 <p>VCD Ansible Modules provide sort of a unanimous response across all operations. The response shall contain atleast following properties,</p>


### PR DESCRIPTION
# Description
Add support for authentication using [API Access Tokens][1]. The authentication follows RFC6749 (OAuth 2.0). This is useful if an [external identity provider][2] is configured for authentication with vCloud Director.

If `user` is set to "API_TOKEN" the `password` is interpreted as token and instead of setting the login credentials of the pyvcloud client, the client's `rehydrate_from_token` function is called with the token and the optional argument `is_jwt_token=True`.

Implements: #223

# Usage
1. [Generate an API Access Token][1]
2. Run an ad-hoc command and test the authentication via API Access Token, e.g.:
   ```
   ansible localhost \
        -m vcd_vapp \
        -a "api_version=34.0
            host=<VCD_HOST>
            operation=list_vms
            org=<VCD_ORG>
            password=<GENERATED_TOKEN>
            user=API_TOKEN
            vapp_name=<VCD_VAPP>
            vdc=<VCD_DATACENTER>"
   ```


[1]: https://docs.vmware.com/en/VMware-Cloud-Director/10.3/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-A1B3B2FA-7B2C-4EE1-9D1B-188BE703EEDE.html
[2]: https://docs.vmware.com/en/VMware-Cloud-Director/10.4/VMware-Cloud-Director-Service-Provider-Admin-Portal-Guide/GUID-3326986B-931C-4FDE-AF47-D5A863191072.html